### PR TITLE
Update JWT packages to 6.36.0

### DIFF
--- a/aspnetcore.ntier.BLL/aspnetcore.ntier.BLL.csproj
+++ b/aspnetcore.ntier.BLL/aspnetcore.ntier.BLL.csproj
@@ -10,13 +10,13 @@
 		<PackageReference Include="AutoMapper" Version="11.0.1" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.13" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.36" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.26.0" />
+		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.36.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.26.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.36.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
According to https://github.com/advisories/GHSA-59j7-ghrg-fj52 , the JWT package at its current version is vulnerable. This PR replaces it with the latest minor version available.