### PR TITLE
Infra/migrate db on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,9 @@ If this repository helped you please consider giving a star! Thanks!
 
 - SQLite has been used as database
 - You can change connection string from *appsettings.json* within *aspnetcore.ntier.API*
-- Apply database migrations to create the tables. From a command line :
+- Make sure proper versions of [.NET SDK](https://automapper.org/) and [dotnet-ef](https://learn.microsoft.com/en-us/ef/core/cli/dotnet) tool are installed
+- Run `aspnetcore.ntier.API` project to start the application
 
-Go into aspnetcore.ntier.DAL class library. Please make sure proper versions of [.NET SDK](https://automapper.org/) and [dotnet-ef](https://learn.microsoft.com/en-us/ef/core/cli/dotnet) tool has been installed
-```
-cd aspnetcore.ntier.DAL
-```
-Apply database changes.
-If you are using SQLite then database file with .db extension should be created inside aspnetcore.ntier.API project
-```
-dotnet ef --startup-project ../aspnetcore.ntier.API database update --context AspNetCoreNTierDbContext
-```
 ## Authentication
 
 - Authentication has been added for version 2 endpoints.

--- a/aspnetcore.ntier.API/Program.cs
+++ b/aspnetcore.ntier.API/Program.cs
@@ -3,10 +3,12 @@ using aspnetcore.ntier.BLL.Utilities.Settings;
 using aspnetcore.ntier.DAL;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using System.Text;
+using aspnetcore.ntier.DAL.DataContext;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -60,6 +62,12 @@ app.UseSwaggerUI(c =>
         c.SwaggerEndpoint($"../swagger/{description.GroupName}/swagger.json", description.GroupName.ToString());
     }
 });
+
+using (var scope = app.Services.CreateScope())
+{
+    var dbContext = scope.ServiceProvider.GetRequiredService<AspNetCoreNTierDbContext>();
+    dbContext.Database.Migrate();
+}
 
 app.Run();
 


### PR DESCRIPTION
This PR migrates the DB on API project startup without running the CLI migration command when running the application for the first time.
This can be confirmed by the following:
1. remove `aspnetcorentier.db`.
2. Run _aspnetcore.ntier.API_.
3. Use one of the `/getusers` routes.
4. The app doesn't break searching for the `Users` table. :)