### PR TITLE
Fix unitests

### DIFF
--- a/aspnetcore.ntier.Test/UnitTests/BLL/Services/AuthServiceTests.cs
+++ b/aspnetcore.ntier.Test/UnitTests/BLL/Services/AuthServiceTests.cs
@@ -9,6 +9,8 @@ using AutoMapper;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using System.Linq.Expressions;
+using aspnetcore.ntier.BLL.Utilities.Settings;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace aspnetcore.ntier.Test.UnitTests.BLL.Services;
@@ -61,12 +63,15 @@ public class AuthServiceTests
         var configurationMock = new Mock<IConfiguration>();
         configurationSectionMock
            .Setup(x => x.Value)
-           .Returns("Superb token for testing purposes");
-        configurationMock
-           .Setup(x => x.GetSection("AppSettings:Token"))
-           .Returns(configurationSectionMock.Object);
+           .Returns("test");
+        var jwtSettingsMock = new JwtSettings
+        {
+            AccessTokenSecret = "Superb token for testing purposes", RefreshTokenSecret = "Superb token for testing purposes", AccessTokenExpirationMinutes = 1,
+            RefreshTokenExpirationMinutes = 1
+        };
+var options = Options.Create(jwtSettingsMock);
 
-        _authService = new AuthService(_userRepository.Object, _mapper, configurationMock.Object);
+        _authService = new AuthService(_userRepository.Object, _mapper, options);
     }
 
     [Fact]

--- a/aspnetcore.ntier.Test/UnitTests/BLL/Services/AuthServiceTests.cs
+++ b/aspnetcore.ntier.Test/UnitTests/BLL/Services/AuthServiceTests.cs
@@ -58,20 +58,14 @@ public class AuthServiceTests
         var myProfile = new AutoMapperProfiles.AutoMapperProfile();
         var mapperConfiguration = new MapperConfiguration(cfg => cfg.AddProfile(myProfile));
         _mapper = new Mapper(mapperConfiguration);
-
-        var configurationSectionMock = new Mock<IConfigurationSection>();
-        var configurationMock = new Mock<IConfiguration>();
-        configurationSectionMock
-           .Setup(x => x.Value)
-           .Returns("test");
         var jwtSettingsMock = new JwtSettings
         {
             AccessTokenSecret = "Superb token for testing purposes", RefreshTokenSecret = "Superb token for testing purposes", AccessTokenExpirationMinutes = 1,
             RefreshTokenExpirationMinutes = 1
         };
-var options = Options.Create(jwtSettingsMock);
+var jwtOptions = Options.Create(jwtSettingsMock);
 
-        _authService = new AuthService(_userRepository.Object, _mapper, options);
+        _authService = new AuthService(_userRepository.Object, _mapper, jwtOptions);
     }
 
     [Fact]


### PR DESCRIPTION
The tests project didn't compile due to `IConfiguration` variable, injected to a service expecting `IOptions<JwtSettings>`.